### PR TITLE
Replace CSS in svg with XML attributes

### DIFF
--- a/src/leaflet.measure.js
+++ b/src/leaflet.measure.js
@@ -198,7 +198,7 @@
         enableClose: function () {
             this._closeButton = L.DomUtil.create("span", "close", this._container);
             this._closeButton.innerHTML =
-                '<svg class="icon" viewBox="0 0 40 40"><path style="stroke:#FF0000;stroke-width:3" d="M 10,10 L 30,30 M 30,10 L 10,30" /></svg>';
+                '<svg class="icon" viewBox="0 0 40 40"><path stroke="#FF0000" stroke-width="3" d="M 10,10 L 30,30 M 30,10 L 10,30" /></svg>';
             return this._closeButton;
         },
     });


### PR DESCRIPTION
The SVG image used for the close button (the small red X) contains inline CSS styles. ThisI won't work with a `Content-Security-Policy` without a `style-src` containing `'unsafe-inline'`. As using `unsafe-inline` is not great for security, I replaced the style with the corresponding XML attributes. This should work even with restricted CSPs.

The looks of the icon should not have changed at all.

Thanks for your work!