### PR TITLE
Prevent link from changing url hash

### DIFF
--- a/src/leaflet.measure.js
+++ b/src/leaflet.measure.js
@@ -267,11 +267,13 @@
             }
         },
         _enableMeasure: function () {
-            this._trail = {
-                overlays: [],
-                points: [],
-            };
             var map = this._map;
+            this._trail = {
+                points: [],
+                overlays: L.featureGroup(),
+            };
+            map.addLayer( this._trail.overlays );
+
             L.DomUtil.addClass(map._container, "leaflet-measure-map");
             map.contextMenu && map.contextMenu.disable();
             this._measurementStarted = true;
@@ -337,8 +339,7 @@
                         interactive: false,
                     });
                 }
-                this._map.addLayer(this._directPath);
-                this._trail.overlays.push(this._directPath);
+                this._trail.overlays.addLayer(this._directPath);
             } else {
                 this._directPath.addLatLng(latlng);
             }
@@ -360,8 +361,7 @@
                         interactive: false,
                     });
                 }
-                this._map.addLayer(this._measurePath);
-                this._trail.overlays.push(this._measurePath);
+                this._trail.overlays.addLayer(this._measurePath);
             } else {
                 this._measurePath.addLatLng(latlng);
             }
@@ -378,8 +378,7 @@
                 radius: 3,
                 interactive: false,
             });
-            this._map.addLayer(marker);
-            this._trail.overlays.push(marker);
+            this._trail.overlays.addLayer(marker);
         },
         _addLable: function (latlng, content, className, ended) {
             var lable = new L.MeasureLable({
@@ -387,20 +386,15 @@
                 content: content,
                 className: className,
             });
-            this._map.addLayer(lable);
-            this._trail.overlays.push(lable);
+            this._trail.overlays.addLayer(lable);
             if (ended) {
                 var closeButton = lable.enableClose();
                 L.DomEvent.on(closeButton, "click", this._clearOverlay, this);
             }
         },
         _clearOverlay: function () {
-            var i = 0,
-                overlays = this._trail.overlays,
-                length;
-            for (length = overlays.length; i < length; i++) {
-                this._map.removeLayer(overlays[i]);
-            }
+            this._map.removeLayer(this._trail.overlays);
+            this._trail.overlays = null;
         },
         toRadians: function (deg) {
             return deg * (Math.PI / 180);

--- a/src/leaflet.measure.js
+++ b/src/leaflet.measure.js
@@ -89,6 +89,7 @@
         },
         _enableMeasureLine: function (ev) {
             L.DomEvent.stopPropagation(ev);
+            L.DomEvent.preventDefault(ev);
             this._measureHandler = new L.MeasureAction(this._map, {
                 model: "distance",
                 color: this.options.color,
@@ -97,6 +98,7 @@
         },
         _enableMeasureArea: function (ev) {
             L.DomEvent.stopPropagation(ev);
+            L.DomEvent.preventDefault(ev);
             this._measureHandler = new L.MeasureAction(this._map, {
                 model: "area",
                 color: this.options.color,

--- a/src/leaflet.measure.js
+++ b/src/leaflet.measure.js
@@ -271,7 +271,14 @@
             this._trail = {
                 points: [],
                 overlays: L.featureGroup(),
+                canvas: map.options.preferCanvas || false,
             };
+            if ( map.options.preferCanvas ) {
+                map.options.preferCanvas = false;
+                console.warn( 'Temporarily reset map.options.prefersCanvas to false' );
+                //HACK: With canvas rendering enabled (and no other markers present on the map), this will create an permanent
+                // overlaying layer of type L.Canvas that swallows mouse events.
+            }
             map.addLayer( this._trail.overlays );
 
             L.DomUtil.addClass(map._container, "leaflet-measure-map");
@@ -395,6 +402,7 @@
         _clearOverlay: function () {
             this._map.removeLayer(this._trail.overlays);
             this._trail.overlays = null;
+            this._map.options.preferCanvas = this._trail.canvas;
         },
         toRadians: function (deg) {
             return deg * (Math.PI / 180);


### PR DESCRIPTION
Currently, a click on either the linear or area measurement start buttons will navigate to `#`, which will reset the scroll position to the top of the current page.

This is especially annoying when the map opens in a popup and the original page is a rather long list (as in our case).

Adding the calls to `L.DomEvent.preventDefault` prevents the browser from navigation and thus from resetting the scroll position.